### PR TITLE
Allow lazy quotes

### DIFF
--- a/easycsv.go
+++ b/easycsv.go
@@ -38,6 +38,10 @@ func newCSVReader(r io.Reader, opt Option) *csv.Reader {
 	if opt.Comment != 0 {
 		cr.Comment = opt.Comment
 	}
+	if opt.LazyQuotes {
+		cr.LazyQuotes = opt.LazyQuotes
+	}
+
 	return cr
 }
 

--- a/option.go
+++ b/option.go
@@ -12,6 +12,8 @@ type Option struct {
 	Comma rune
 	// Comment, if not 0, is the comment character. Lines beginning with the character without preceding whitespace are ignored.
 	Comment rune
+	// Allow lazy parsing of quotes, default to false
+	LazyQuotes bool
 	// Decoders is the map to define custom encodings.
 	Decoders map[string]interface{}
 	// Custom decoders to parse specific types.
@@ -35,6 +37,9 @@ func (a *Option) mergeOption(b Option) {
 	}
 	if b.AutoName {
 		a.AutoName = true
+	}
+	if b.LazyQuotes {
+		a.LazyQuotes = b.LazyQuotes
 	}
 	if b.Decoders != nil {
 		if a.Decoders == nil {

--- a/option_test.go
+++ b/option_test.go
@@ -38,6 +38,22 @@ func TestSkipComment(t *testing.T) {
 	}
 }
 
+func TestLazyQuotes(t *testing.T) {
+	f := bytes.NewBufferString("1,2,3,\"\"4\",5")
+	r := NewReader(f, Option{
+		LazyQuotes: true,
+		Comment:    '#',
+	})
+	var content [][]string
+	if err := r.ReadAll(&content); err != nil {
+		t.Error(err)
+	}
+	expected := [][]string{{"1", "2", "3", "\"4", "5"}}
+	if !reflect.DeepEqual(expected, content) {
+		t.Errorf("Expected %v but got %v", expected, content)
+	}
+}
+
 func TestOptionWithNewReadCloser(t *testing.T) {
 	f := &fakeCloser{
 		reader: bytes.NewBufferString("1\t2\n3\t4\n"),


### PR DESCRIPTION
I needed to expose the lazy quotes option

```
        // If LazyQuotes is true, a quote may appear in an unquoted field and a
        // non-doubled quote may appear in a quoted field.
        LazyQuotes bool
```
https://golang.org/pkg/encoding/csv/