### PR TITLE
Allow missing fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,8 @@ Like [csv.Reader](https://golang.org/pkg/encoding/csv/#Reader) in the standard l
 ## Comment
 Comment, if not 0, is the comment character. Lines beginning with the character without preceding whitespace are ignored.
 
-## AllowMissingFields
-In the standard library [csv.Reader](https://golang.org/pkg/encoding/csv/#Reader), an option `FieldsPerRecord` is available to define the number of fields allowed per CSV record. When `AllowMissingFields` is true, the field `FieldsPerRecord` is set to -1, and Reader does not check the number of fields per record.
+## FieldsPerRecord
+In the standard library [csv.Reader](https://golang.org/pkg/encoding/csv/#Reader), an option `FieldsPerRecord` is available to define the number of fields allowed per CSV record. If you set a value that is not 0 to `FieldsPerRecord`, this option will be updated.
 
 # Customizing decoders
 By default, easycsv converts strings in CSV to integers, floats and bool automatically based on the types of struct fields and slices.

--- a/README.md
+++ b/README.md
@@ -184,6 +184,9 @@ Like [csv.Reader](https://golang.org/pkg/encoding/csv/#Reader) in the standard l
 ## Comment
 Comment, if not 0, is the comment character. Lines beginning with the character without preceding whitespace are ignored.
 
+## AllowMissingFields
+In the standard library [csv.Reader](https://golang.org/pkg/encoding/csv/#Reader), an option `FieldsPerRecord` is available to define the number of fields allowed per CSV record. When `AllowMissingFields` is true, the field `FieldsPerRecord` is set to -1, and Reader does not check the number of fields per record.
+
 # Customizing decoders
 By default, easycsv converts strings in CSV to integers, floats and bool automatically based on the types of struct fields and slices.
 

--- a/easycsv.go
+++ b/easycsv.go
@@ -41,6 +41,9 @@ func newCSVReader(r io.Reader, opt Option) *csv.Reader {
 	if opt.LazyQuotes {
 		cr.LazyQuotes = opt.LazyQuotes
 	}
+	if opt.AllowMissingFields {
+		cr.FieldsPerRecord = -1
+	}
 
 	return cr
 }

--- a/easycsv.go
+++ b/easycsv.go
@@ -41,8 +41,8 @@ func newCSVReader(r io.Reader, opt Option) *csv.Reader {
 	if opt.LazyQuotes {
 		cr.LazyQuotes = opt.LazyQuotes
 	}
-	if opt.AllowMissingFields {
-		cr.FieldsPerRecord = -1
+	if opt.FieldsPerRecord != 0 {
+		cr.FieldsPerRecord = opt.FieldsPerRecord
 	}
 
 	return cr

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module easycsv
+
+go 1.13
+
+require github.com/google/go-cmp v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
+github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/option.go
+++ b/option.go
@@ -14,6 +14,8 @@ type Option struct {
 	Comment rune
 	// Allow lazy parsing of quotes, default to false
 	LazyQuotes bool
+	// If true, Reader does not check the number of fields per record
+	AllowMissingFields bool
 	// Decoders is the map to define custom encodings.
 	Decoders map[string]interface{}
 	// Custom decoders to parse specific types.
@@ -40,6 +42,9 @@ func (a *Option) mergeOption(b Option) {
 	}
 	if b.LazyQuotes {
 		a.LazyQuotes = b.LazyQuotes
+	}
+	if b.AllowMissingFields {
+		a.AllowMissingFields = true
 	}
 	if b.Decoders != nil {
 		if a.Decoders == nil {

--- a/option.go
+++ b/option.go
@@ -14,8 +14,10 @@ type Option struct {
 	Comment rune
 	// Allow lazy parsing of quotes, default to false
 	LazyQuotes bool
-	// If true, Reader does not check the number of fields per record
-	AllowMissingFields bool
+	// If negative, Reader does not check the number of fields per record
+	// If 0, this option does not update Reader
+	// If positive, Reader requires all records to have this number of fields
+	FieldsPerRecord int
 	// Decoders is the map to define custom encodings.
 	Decoders map[string]interface{}
 	// Custom decoders to parse specific types.
@@ -43,8 +45,8 @@ func (a *Option) mergeOption(b Option) {
 	if b.LazyQuotes {
 		a.LazyQuotes = b.LazyQuotes
 	}
-	if b.AllowMissingFields {
-		a.AllowMissingFields = true
+	if b.FieldsPerRecord != 0 {
+		a.FieldsPerRecord = b.FieldsPerRecord
 	}
 	if b.Decoders != nil {
 		if a.Decoders == nil {

--- a/option_test.go
+++ b/option_test.go
@@ -50,12 +50,10 @@ func TestLazyQuotes(t *testing.T) {
 	noDiff(t, "ReadAll() with LazyQuotes", got, want)
 }
 
-func TestAllowMissingFields(t *testing.T) {
+func TestFieldsPerRecord(t *testing.T) {
 	csvContents := "1,2,3,4,5\n6,7,8"
 	f := bytes.NewBufferString(csvContents)
-	r := NewReader(f, Option{
-		AllowMissingFields: false,
-	})
+	r := NewReader(f)
 	var got [][]int
 	if err := r.ReadAll(&got); err == nil {
 		t.Fatal("Should have failed to read with error 'record on line 2: wrong number of fields'")
@@ -63,14 +61,14 @@ func TestAllowMissingFields(t *testing.T) {
 
 	f = bytes.NewBufferString(csvContents)
 	r = NewReader(f, Option{
-		AllowMissingFields: true,
+		FieldsPerRecord: -1,
 	})
 	got = [][]int{}
 	if err := r.ReadAll(&got); err != nil {
 		t.Fatalf("Failed to read: %v", err)
 	}
 	want := [][]int{{1, 2, 3, 4, 5}, {6, 7, 8}}
-	noDiff(t, "ReadAll() with AllowMissingFields", got, want)
+	noDiff(t, "ReadAll() with FieldsPerRecord", got, want)
 }
 
 func TestOptionWithNewReadCloser(t *testing.T) {

--- a/option_test.go
+++ b/option_test.go
@@ -50,6 +50,29 @@ func TestLazyQuotes(t *testing.T) {
 	noDiff(t, "ReadAll() with LazyQuotes", got, want)
 }
 
+func TestAllowMissingFields(t *testing.T) {
+	csvContents := "1,2,3,4,5\n6,7,8"
+	f := bytes.NewBufferString(csvContents)
+	r := NewReader(f, Option{
+		AllowMissingFields: false,
+	})
+	var got [][]int
+	if err := r.ReadAll(&got); err == nil {
+		t.Fatal("Should have failed to read with error 'record on line 2: wrong number of fields'")
+	}
+
+	f = bytes.NewBufferString(csvContents)
+	r = NewReader(f, Option{
+		AllowMissingFields: true,
+	})
+	got = [][]int{}
+	if err := r.ReadAll(&got); err != nil {
+		t.Fatalf("Failed to read: %v", err)
+	}
+	want := [][]int{{1, 2, 3, 4, 5}, {6, 7, 8}}
+	noDiff(t, "ReadAll() with AllowMissingFields", got, want)
+}
+
 func TestOptionWithNewReadCloser(t *testing.T) {
 	f := &fakeCloser{
 		reader: bytes.NewBufferString("1\t2\n3\t4\n"),


### PR DESCRIPTION
I'd like to be able to parse without errors when a file contains CSV records with a variable number of fields
In the standard golang CSV library (https://golang.org/pkg/encoding/csv/), it's possible when updating `FieldsPerRecord` 