### PR TITLE
fix module name in go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module easycsv
+module github.com/yunabe/easycsv
 
 go 1.13
 


### PR DESCRIPTION
Sorry for this typo. This wrong name causes issues with module dependencies in go 1.13